### PR TITLE
Support eslint@7 and typescript@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.0.0",
-    "eslint": "^6.5.1",
+    "eslint": "^6.5.1 || ^7.0.0",
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.3.0",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^2.2.0",
     "prettier": "^2.2.1",
-    "typescript": "^4.1.3"
+    "typescript": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "install-peers-cli": "^2.2.0"


### PR DESCRIPTION
For a project that is on an older TypeScript version and a newer eslint version. I think widening these peer dependencies has no impact.