### PR TITLE
Bump eslint-config-prettier peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.0.0",
     "eslint": "^6.5.1 || ^7.0.0",
-    "eslint-config-prettier": "^6.4.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.21.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.20.0",


### PR DESCRIPTION
Bumped `eslint-config-prettier` to `8.3.0`